### PR TITLE
Performance improvements & other tweaks

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -1,4 +1,7 @@
 {
   "$extends": ["#big_world"],
-  "#bgColor": [0.5, 0.8, 1.0, 1.0]
+  "#bgColor": [0.5, 0.8, 1.0, 1.0],
+  "generation": {
+    "wSize": [24, 16, 24]
+  }
 }

--- a/configs/default.json
+++ b/configs/default.json
@@ -24,7 +24,7 @@
   },
   "controls": {
     "$class": "ControlsConfig",
-    "sensitivity": 0.5,
+    "sensitivity": 0.2,
     "vRotRange": [
       -80,
       80

--- a/perf_improvement_ideas.md
+++ b/perf_improvement_ideas.md
@@ -1,0 +1,37 @@
+# Ideas to improve performance
+- Currently, the slowest tyhing is the rendering as not much else happens (yet)
+
+## 1. Caching meshes
+- Cache the mesh for each chunk
+- This could even be split further into sub-chunks (perhaps 4x4x4 or 8x8x8)
+
+### Ticks
+- Every tick/frame (same thing for now), `hasChanged` set to `false` in each chunk
+- If a block is changed, set `hasChanged` to `true` in that chunk
+
+### Rendering
+- Rendering is done after the tick takes place
+- Each chunk has its own mesh
+- Those meshes are `concat`-ed together into a single mesh
+- For each chunk:
+  - If `hasChanged` is `true` for that chunk, recalculate the mesh and re-insert it into global mesh table
+  - If `hasChanged` is `false` for that chunk, continue onto next chunk
+
+#### Async?
+- Same as above except:
+- When a chunk needs to be recalculated, make an async thing that reinserts it into global mesh table once complete.
+- This way, the main 'thread' isn't blocked by recalculating the mesh
+- Also, a serial number also needs to exist so that an earlier mesh doesn't accidentally override later mesh that finished earlier
+- Actually, there is no real way to make it truly async apart from using workers (?)
+- However, if 2 changes happened very quickly it might be a waste to recalculate the mesh twice (if the first one has not been calculated by the time the second changes take place).
+
+##### Cancelling outdated calculations
+- This should only be done if
+  - a new one comes in within a certain amount of the previous calculation and
+  - the first one isn't already complete / has just started
+- Is there an easy way to cancel the previous calculation?
+  - There is no built-in way to cancel promises
+  - Perhaps this could be done by checking for the condition every `n` vertices
+- However, the calculations will probably be quite small so cancelling them probably won't be worth it as they will have already completed
+- Also, if lots of events happen very closes together (eg. insta-mining), the mesh might not be updated at all as the previous one keep getting discarded before being complete
+- Therefore, this isn't really needed because of all the drawbacks

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -145,7 +145,7 @@ function getConfigFilename(/** @type {string} */path) {
     throw new ReferenceError("Config paths shouldn't contain '..'");
   }
   path = trim(path, './', { start: true });
-  path = path.replace(/\/\/*/, '/');  // remove repeated /
+  path = path.replace(/\/+/, '/');  // remove repeated /
   if (!path.endsWith('.json')) { path += '.json'; }
   return '/' + (path.startsWith("configs/") ? path : 'configs/' + path);
 }

--- a/src/game.js
+++ b/src/game.js
@@ -17,6 +17,8 @@ export class Game {
     this.onInit = null;
     this.startTicks = false;
     this.progress = window.progress;
+    this.frameNo = -1;
+    this.tickNo  = -1;
   }
 
   async init() {
@@ -95,6 +97,7 @@ export class Game {
     if (now == null) {
       return this.registerOnFrame();
     }
+    this.frameNo++;
     this.now = now * 0.001;
     this.then ??= this.now;
     this.deltaT = this.now - this.then;
@@ -104,15 +107,23 @@ export class Game {
   }
 
   onframe() {
+    // unconditional re-render on first frame and every 30th frame
+    this.rerender ||= this.frameNo % 30 == 0;
     if(this.startTicks){
       this.tick();
     }
     this.r.renderFrame();
+    this.rerender = false;
   }
 
   tick() {
+    this.tickNo++;
     this.ki.tick(this.deltaT);
     this.player.tick();
+    if(this.tickNo==0){
+      // re-render on first tick
+      this.rerender = true;
+    }
   }
 
   registerOnFrame() {

--- a/src/game.js
+++ b/src/game.js
@@ -112,8 +112,9 @@ export class Game {
     if(this.startTicks){
       this.tick();
     }
-    this.r.renderFrame();
+    let remakeMesh = this.rerender;
     this.rerender = false;
+    this.r.renderFrame(remakeMesh);
   }
 
   tick() {

--- a/src/player.js
+++ b/src/player.js
@@ -34,12 +34,26 @@ export class Player extends GameComponent {
    */
   clampMouseMovementPart(e, part){
     return clamp(
-      part==0 ? e.movementX : e.movementY,
+      this.getMouseMovementPart(e, part),
       -this.cnf.controls.maxMouseMove[part],
       this.cnf.controls.maxMouseMove[part]
       );
   }
-
+  
+  /**
+   * Returns a part (x or y) of the mouse movement (from event `e`)
+   * (not clamped)
+   * @param {MouseEvent} e - The event to get values from
+   * @param {number} part - Which part of the movement (0=x, 1=y)
+   * @returns {number} the clamped value
+   */
+  getMouseMovementPart(e, part) {
+    return part==0 ? e.movementX : e.movementY
+  }
+  static getMouseMovementPart(e, part) {
+    return this.prototype.getMouseMovementPart(e, part);
+  }
+  
   clampRot(){
     this.rotation.v = clamp(
       this.rotation.v,

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -22,9 +22,10 @@ import {ElementBundler} from './vertex_bundle.js';
 // North = +z
 
 
+// thing i could eventually read:
 // https://www.toptal.com/game/video-game-physics-part-i-an-introduction-to-rigid-body-dynamics
 
-// TODO: switch to typescript?
+// TODO: switch to typescript??
 export class Renderer extends GameComponent {
   constructor(game, do_init = true) {
     super(game);
@@ -136,11 +137,12 @@ export class Renderer extends GameComponent {
   }
   
   // DRAW SCENE
-  renderFrame(){
+  renderFrame(remakeMesh){
+    this.remakeMesh = remakeMesh;
     this.initFrame();
-    if(this.game.rerender){
+    if(this.remakeMesh){
       // only update mesh if re-render
-      this.addWorldData();
+      this.makeWorldMesh();
     }
     this.drawAll();
     this.checkGlFault();
@@ -162,7 +164,7 @@ export class Renderer extends GameComponent {
   }
 
   // CUBE DATA HANDLING
-  addWorldData(){
+  makeWorldMesh(){
     this.vertexData.reset();
     for(const [pos, block] of this.world){
       this.addBlock(pos, block);

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -138,7 +138,10 @@ export class Renderer extends GameComponent {
   // DRAW SCENE
   renderFrame(){
     this.initFrame();
-    this.addWorldData();
+    if(this.game.rerender){
+      // only update mesh if re-render
+      this.addWorldData();
+    }
     this.drawAll();
     this.checkGlFault();
   }
@@ -156,11 +159,11 @@ export class Renderer extends GameComponent {
 
   resetRender(){
     this.clearCanvas();
-    this.vertexData.reset();
   }
 
   // CUBE DATA HANDLING
   addWorldData(){
+    this.vertexData.reset();
     for(const [pos, block] of this.world){
       this.addBlock(pos, block);
     }


### PR DESCRIPTION
- Improve performance **A LOT**
  - Don't recalculate world mesh every frame
  - Only recalculate it when modified
  - Also recalculate it every 30 frames (0.5s)
- Drastically decease default mouse sensitivity
- Minor tidy up