### PR TITLE
Fix github pages error (again!)

### DIFF
--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -130,7 +130,7 @@ export async function loadConfigByName(/**@type{string}*/name) {
 
 export async function loadConfigDefaults() {
   return loadConfigFile(
-    "/configs/default.json",
+    "./configs/default.json",
     // IMPORTANT: this is so that no infinite recursion getting defaults for default
     false);
 }

--- a/src/utils/file_load.js
+++ b/src/utils/file_load.js
@@ -4,22 +4,24 @@ export function loadTextFromTag(id){
   return vse.innerText;
 }
 
-export async function fetchTextFile(path){
+export async function fetchResponse(path) {
+  if(path.startsWith('/')) {
+    console.warn("Using absolute paths that will not work when used with github pages")
+  }
   // todo use XMLHttpRequest for progress event (only needed when bigger files)
   const response = await fetch(path);
   if (!response.ok) {
     throw new Error(`cant load resource at ${path}`);
   }
-  return response.text();
+  return response;
+}
+
+export async function fetchTextFile(path){
+  return (await fetchResponse(path)).text();
 }
 
 export async function fetchJsonFile(path){
-  // todo use XMLHttpRequest for progress event (only needed when bigger files)
-  const response = await fetch(path);
-  if (!response.ok) {
-    throw new Error(`cant load resource at ${path}`);
-  }
-  return response.json();
+  return (await fetchResponse(path)).json();
 }
 
 /**


### PR DESCRIPTION
- Fix github pages error (again!)
- Add warning to `fetchTextFile` when using absolute paths because they break when using github pages
- Refactor `fetch*`