### PR TITLE
Don't import all utils

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
       # see https://www.npmjs.com/package/eslint#installation-and-usage
       - name: Run eslint
         run: ./node_modules/.bin/eslint --max-warnings 0 ./
+      - name: Run custom linters
+        run: node ./scripts/find_bad_import.js
   
   
   build:

--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
   <link rel="modulepreload" href="src/world/seed.js">
   <link rel="modulepreload" href="src/world/base_generator.js">
   <link rel="modulepreload" href="src/alea/alea.js">
+  <link rel="modulepreload" href=src/utils/array_utils.js>
+  <link rel="modulepreload" href=src/utils/deep_merge.js>
+  <link rel="modulepreload" href=src/utils/type_check.js>
+  <link rel="modulepreload" href=src/utils/str_utils.js>
+  <link rel="modulepreload" href=src/utils/assert.js>
+  <link rel="modulepreload" href=src/utils/object_utils.js>
   <link rel="prefetch" href="configs/config.json" as="fetch">
   <link rel="prefetch" href="configs/default.json" as="fetch">
   <link rel="prefetch" href="shaders/fragment-shader.glsl" as="fetch">

--- a/scripts/find_bad_import.js
+++ b/scripts/find_bad_import.js
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { join, normalize } from "node:path";
+import { join, resolve } from "node:path";
 
 const FILE_EXT_RE = /\.([mc]?)(js|ts)(x?)/;
 
@@ -65,7 +65,7 @@ function chainAsyncIterables(...iters) {
 
 function pathEq(a, b) {
   // not sure if this aloways works but good enough
-  return normalize(a) === normalize(b);
+  return resolve(a) === resolve(b);
 }
 
 function shouldSkip(/**@type {WalkDirObj}*/o) {
@@ -100,7 +100,7 @@ async function handleFile(/**@type {WalkDirObj}*/f) {
 }
 
 function formatFailure(f) {
-  let s = `${normalize(f.path)}\n`
+  let s = `${resolve(f.path)}\n`
     + `Error:   ${f.line}:${f.col}  error  `
     + `Shouldn't import from 'utils/index.js' no-import-all-utils`;
   return s;

--- a/scripts/find_bad_import.js
+++ b/scripts/find_bad_import.js
@@ -100,9 +100,9 @@ async function handleFile(/**@type {WalkDirObj}*/f) {
 }
 
 function formatFailure(f) {
-  let s = `${resolve(f.path)}\n`
+  let s = `\n${resolve(f.path)}\n`
     + `\x1b[31mError:\x1b[39m   ${f.line}:${f.col}  error  `
-    + `Shouldn't import from 'utils/index.js' no-import-all-utils`;
+    + `Shouldn't import from utils/index.js  no-import-all-utils\n`;
   return s;
 }
 

--- a/scripts/find_bad_import.js
+++ b/scripts/find_bad_import.js
@@ -91,7 +91,8 @@ async function handleFile(/**@type {WalkDirObj}*/f) {
     if(index < 0) {
       continue;
     }
-    if(/noqa:\s*no-import-all-utils/i.test(line)) {
+    let noqa = /noqa:\s*no-import-all-utils/i.test(line) || /noqa([^:]|$)/.test(line);
+    if(noqa) {
       continue;
     }
     failures.push({path: f.path, line: i+1, col: index});

--- a/scripts/find_bad_import.js
+++ b/scripts/find_bad_import.js
@@ -1,0 +1,129 @@
+import * as fs from "node:fs";
+import { join, normalize } from "node:path";
+
+const FILE_EXT_RE = /\.([mc]?)(js|ts)(x?)/;
+
+/**
+ * @typedef {Object} WalkDirObj
+ * @prop {string} path
+ * @prop {string} name
+ * @prop {string} parent
+ * @prop {fs.Dirent} dirent
+ * @prop {(() => void) | undefined} ignore
+*/
+/**
+ * @typedef {Object} WalkDirConfig
+ * @prop {boolean} [skipExotic=true]
+ * @prop {boolean} [skipDir=true]
+*/
+
+/**
+ * @param {string} dir
+ * @param {WalkDirConfig} cnf
+ * @returns {AsyncIterable<WalkDirObj>}
+ */
+function walkDir(dir, cnf={}) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for await (let de of await fs.promises.opendir(dir)) {
+        let path = join(dir, de.name);
+        if(de.isDirectory()) {
+          let ignored = false;
+          if(!(cnf.skipDir ?? true)) {
+            yield {path, parent: dir, name: de.name, dirent: de, ignore() {
+              ignored = true;
+            }};
+          }
+          if(!ignored) {
+            yield* walkDir(path, cnf);
+          }
+          continue;
+        }
+        if((cnf.skipExotic ?? true) && !de.isFile()) {
+          continue;
+        }
+        yield {path, parent: dir, name: de.name, dirent: de};
+      }
+    }
+  }
+}
+
+/**
+ * @template T
+ * @param {AsyncIterable<T>[]} iters
+ * @returns {AsyncIterable<T>}
+*/
+function chainAsyncIterables(...iters) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for(const iter of iters) {
+        yield* iter;
+      }
+    }
+  }
+}
+
+function pathEq(a, b) {
+  // not sure if this aloways works but good enough
+  return normalize(a) === normalize(b);
+}
+
+function shouldSkip(/**@type {WalkDirObj}*/o) {
+  return pathEq(o.path, "test/coverage") || pathEq(o.path, "src/libs");
+}
+
+async function handleFile(/**@type {WalkDirObj}*/f) {
+  if(!FILE_EXT_RE.test(f.name)) {
+    return [];
+  }
+  let failures = [];
+  let text = (await fs.promises.readFile(f.path)).toString();
+  for(let [i, line] of text.split('\n').entries()) {
+    let searchFor = pathEq(f.parent, "src/utils")
+      ? ['utils/index.js']: ['./index.js', 'utils/index.js'];
+    let index = 0;
+    for(let s of searchFor) {
+      index = line.indexOf(s);
+      if(index > 0) {
+        break;
+      }
+    }
+    if(index < 0) {
+      continue;
+    }
+    if(/noqa:\s*no-import-all-utils/i.test(line)) {
+      continue;
+    }
+    failures.push({path: f.path, line: i+1, col: index});
+  }
+  return failures;
+}
+
+function formatFailure(f) {
+  let s = `${normalize(f.path)}\n`
+    + `Error:   ${f.line}:${f.col}  error  `
+    + `Shouldn't import from 'utils/index.js' no-import-all-utils`;
+  return s;
+}
+
+let failures = [];
+
+for await (let wd of chainAsyncIterables(
+    walkDir("./src", {skipDir: false}), 
+    walkDir("./test", {skipDir: false}))) {
+  let de = wd.dirent;
+  if(de.isDirectory()) {
+    if(shouldSkip(wd)) {
+      wd.ignore();
+    }
+    continue;
+  }
+  failures.push(...await handleFile(wd));
+}
+
+if(failures.length > 0) {
+  for(let f of failures) {
+    console.log(formatFailure(f));
+  }
+  process.exitCode = 1;
+}

--- a/scripts/find_bad_import.js
+++ b/scripts/find_bad_import.js
@@ -101,7 +101,7 @@ async function handleFile(/**@type {WalkDirObj}*/f) {
 
 function formatFailure(f) {
   let s = `${resolve(f.path)}\n`
-    + `Error:   ${f.line}:${f.col}  error  `
+    + `\x1b[31mError:\x1b[39m   ${f.line}:${f.col}  error  `
     + `Shouldn't import from 'utils/index.js' no-import-all-utils`;
   return s;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { assignNullSafe } from './utils/array_utils.js'; 
+import { assignNullSafe } from './utils/array_utils.js';
 import { deepMerge } from './utils/deep_merge.js';
 
 import { LoaderContext } from "./config_loader.js";

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,6 @@
-import { assignNullSafe, deepMerge } from './utils.js';
+import { assignNullSafe } from './utils/array_utils.js'; 
+import { deepMerge } from './utils/deep_merge.js';
+
 import { LoaderContext } from "./config_loader.js";
 
 

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -1,11 +1,9 @@
 "use strict";
-import {
-  isPureObject, isObject,
-  fetchTextFile, 
-  trim, 
-  deepMerge, 
-  removePrefix
-} from "./utils.js";
+import { isPureObject, isObject } from "./utils/type_check.js";
+import { removePrefix, trim } from "./utils/str_utils.js";
+import { deepMerge } from "./utils/deep_merge.js";
+import { fetchTextFile } from "./utils/file_load.js";
+
 import * as CNF_MOD from "./config.js";
 
 

--- a/src/dyn_info.js
+++ b/src/dyn_info.js
@@ -1,5 +1,5 @@
 import { GameComponent } from "./game_component.js";
-import { roundNearest } from "./utils.js";
+import { roundNearest } from "./utils/math.js";
 
 
 export class DynInfo extends GameComponent {

--- a/src/dyn_info.js
+++ b/src/dyn_info.js
@@ -1,5 +1,5 @@
 import { GameComponent } from "./game_component.js";
-import { roundNearest } from "./utils/index.js";  // noqa: no-import-all-utils
+import { roundNearest } from "./utils/math.js";
 
 
 export class DynInfo extends GameComponent {

--- a/src/dyn_info.js
+++ b/src/dyn_info.js
@@ -1,5 +1,5 @@
 import { GameComponent } from "./game_component.js";
-import { roundNearest } from "./utils/index.js";
+import { roundNearest } from "./utils/index.js";  // noqa: no-import-all-utils
 
 
 export class DynInfo extends GameComponent {

--- a/src/dyn_info.js
+++ b/src/dyn_info.js
@@ -1,5 +1,5 @@
 import { GameComponent } from "./game_component.js";
-import { roundNearest } from "./utils/math.js";
+import { roundNearest } from "./utils/index.js";
 
 
 export class DynInfo extends GameComponent {

--- a/src/keyinput.js
+++ b/src/keyinput.js
@@ -1,4 +1,4 @@
-import {charIsDigit} from './utils.js';
+import { charIsDigit } from './utils/math.js';
 
 export class KeyInput {
   constructor(){

--- a/src/player.js
+++ b/src/player.js
@@ -1,6 +1,6 @@
 import {GameComponent} from './game_component.js';
 import {KeyEvent} from './keyinput.js';
-import {clamp, toRad} from './utils.js';
+import {clamp, toRad} from './utils/math.js';
 
 
 export class Player extends GameComponent {

--- a/src/renderer/atlas_data.js
+++ b/src/renderer/atlas_data.js
@@ -1,4 +1,4 @@
-import { fetchJsonFile } from "./utils/file_load.js";
+import { fetchJsonFile } from "../utils/file_load.js";
 import { loadTexture } from '../utils/gl_utils.js';
 
 import { GameComponent } from '../game_component.js';

--- a/src/renderer/atlas_data.js
+++ b/src/renderer/atlas_data.js
@@ -1,5 +1,8 @@
-import {GameComponent} from '../game_component.js';
-import {fetchJsonFile, loadTexture} from '../utils.js';
+import { fetchJsonFile } from "./utils/file_load.js";
+import { loadTexture } from '../utils/gl_utils.js';
+
+import { GameComponent } from '../game_component.js';
+
 
 export class AtlasEntry {
   constructor(aData, name, i){

--- a/src/renderer/buffers.js
+++ b/src/renderer/buffers.js
@@ -1,7 +1,8 @@
 progress.addPercent(10);
 
-import {isNumber, nameOrValue, expectValue} from "../utils.js";
-import {GameComponent} from "../game_component.js";
+import { isNumber } from "../utils/type_check.js";
+import { nameOrValue, expectValue } from "../utils/general.js";
+import { GameComponent } from "../game_component.js";
 
 
 export class Buffers extends GameComponent {

--- a/src/renderer/cube_data.js
+++ b/src/renderer/cube_data.js
@@ -1,4 +1,5 @@
-import { sortCoords, isObject } from '../utils.js';
+import { isObject } from "../utils/type_check.js";
+import { sortCoords } from '../utils/array_utils.js';
 import { GameComponent } from '../game_component.js';
 
 

--- a/src/renderer/face_culling.js
+++ b/src/renderer/face_culling.js
@@ -1,5 +1,5 @@
+import {unreachable} from '../utils/assert.js';
 import {GameComponent} from '../game_component.js';
-import {unreachable} from '../utils.js';
 import {CubeVertexData} from './cube_data.js';
 
 /**

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,12 +1,7 @@
-import {
-  // math
-  toRad,
-  // webgl
-  getGL, glErrnoToMsg,
-  // other
-  LoaderMerge
-} from '../utils.js';
-import {GameComponent} from '../game_component.js';
+import { toRad } from "../utils/math.js";
+import { getGL, glErrnoToMsg } from "../utils/gl_utils.js";
+import { LoaderMerge } from '../utils/loader.js';
+import { GameComponent } from '../game_component.js';
 
 import {Buffers} from './buffers.js';
 import {AtlasLoader} from './atlas_data.js';

--- a/src/renderer/shader_loader.js
+++ b/src/renderer/shader_loader.js
@@ -1,9 +1,9 @@
-import {
-  expectValue,
-  loadShader, programFromShaders,
-  fetchTextFile
-} from '../utils.js';
-import {GameComponent} from '../game_component.js';
+import { expectValue } from '../utils/general.js';
+import { fetchTextFile } from '../utils/file_load.js';
+import { loadShader, programFromShaders } from '../utils/gl_utils.js';
+
+import { GameComponent } from '../game_component.js';
+
 
 export class ShaderLoader extends GameComponent {
   constructor(game){
@@ -35,4 +35,3 @@ export class ShaderLoader extends GameComponent {
     return (this[result_attr_name] = result);
   }
 }
-

--- a/src/renderer/vertex_bundle.js
+++ b/src/renderer/vertex_bundle.js
@@ -1,6 +1,5 @@
-import { glTypeSize } from '../utils.js';
+import { glTypeSize } from '../utils/gl_utils.js';
 import { GameComponent } from '../game_component.js';
-
 
 
 // simply a container utility class for each 'section' of vertex data

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,1 +1,0 @@
-export * from "./utils/index.js";

--- a/src/world/block_type.js
+++ b/src/world/block_type.js
@@ -1,4 +1,7 @@
-import {isString, classOf, assert, fromKeys, setDefaults, assignNullSafe} from '../utils.js';
+import { isString, classOf } from "../utils/type_check.js";
+import { assert } from "../utils/assert.js";
+import { fromKeys } from "../utils/general.js";
+import { setDefaults, assignNullSafe } from '../utils/array_utils.js';
 
 /**
  * Type of the argument to `new BlockType()`

--- a/src/world/chunk.js
+++ b/src/world/chunk.js
@@ -1,4 +1,5 @@
-import { assert, divmod } from '../utils.js';
+import { assert } from '../utils/assert.js';
+import { divmod } from "../utils/math.js";
 import { GameComponent } from '../game_component.js';
 
 import { Blocks } from './block_type.js';

--- a/src/world/generation.js
+++ b/src/world/generation.js
@@ -1,5 +1,5 @@
 import { GameComponent } from "../game_component.js";
-import { rangeList } from "../utils.js";
+import { rangeList } from "../utils/array_utils.js";
 
 import { World } from "./world.js";
 import { Blocks } from "./block_type.js";

--- a/src/world/seed.js
+++ b/src/world/seed.js
@@ -1,4 +1,4 @@
-import { rangeList } from "../utils.js";
+import { rangeList } from "../utils/array_utils.js";
 
 
 export class SeedFork {

--- a/src/world/tree_generation.js
+++ b/src/world/tree_generation.js
@@ -1,5 +1,5 @@
 import { alea } from "../alea/alea.js";
-import { rangeFrom, rangeList } from "../utils.js";
+import { rangeFrom, rangeList } from "../utils/array_utils.js";
 import { BaseGenerator } from "./base_generator.js";
 
 

--- a/src/world/world.js
+++ b/src/world/world.js
@@ -1,5 +1,7 @@
+import { assert } from "../utils/assert.js";
+import { fromNested } from "../utils/array_utils.js";
 import { GameComponent } from "../game_component.js";
-import { assert, fromNested } from "../utils.js";
+
 import { Blocks } from "./block_type.js";
 import { Chunk } from "./chunk.js";
 


### PR DESCRIPTION
Don't import all utils from `utils.js` or `utils/index.js`, closes #127.

- [x] Remove all usages
- [x] Add workflow to check for this