### PR TITLE
Update `stringifyJsonConfig`

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,3 +1,4 @@
 {
-  "include": ["src/**/*.js", "src"]
+  "include": ["src/**/*.js", "src"],
+  "lib": "esnext"
 }

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -110,7 +110,7 @@ function configJsonReplacer(_key, value) {
     return value;
   } 
   // only do own symbols
-  let symbols = Object.getOwnPropertySymbols(o);
+  let symbols = Object.getOwnPropertySymbols(value);
   if(symbols.length) {
     value = {...value};  // shallow-copy to not change original object
     for(let s of symbols) {

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -115,6 +115,9 @@ function configJsonReplacer(_key, value) {
     value = {...value};  // shallow-copy to not change original object
     for(let s of symbols) {
       let desc = s.description;
+      if(desc.startsWith('Symbol.')) {
+        desc = removePrefix(desc, "Symbol.");
+      }
       let new_key = '@@' + desc;
       value[new_key] = value[s];
       delete value[s];

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -106,7 +106,21 @@ function configJsonReplacer(_key, value) {
   if (value == -Infinity) {
     return "-Infinity";
   }
-  if (isObject(value) && !isPureObject(value)) {
+  if(!isObject(value)) {
+    return value;
+  } 
+  // only do own symbols
+  let symbols = Object.getOwnPropertySymbols(o);
+  if(symbols.length) {
+    value = {...value};  // shallow-copy to not change original object
+    for(let s of symbols) {
+      let desc = s.description;
+      let new_key = '@@' + desc;
+      value[new_key] = value[s];
+      delete value[s];
+    }
+  }
+  if (!isPureObject(value)) {
     return { $class: value.constructor.name, ...value };
   }
   return value;

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -108,7 +108,14 @@ function configJsonReplacer(_key, value) {
   }
   if(!isObject(value)) {
     return value;
-  } 
+  }
+  for(let k of Object.keys(value)) {
+    if(isComment(k)) {
+      throw new Error(
+        "Config to be strinfiy-ed contains comment keys "
+        + "that would be ignored when being loaded");
+    }
+  }
   // only do own symbols
   let symbols = Object.getOwnPropertySymbols(value);
   if(symbols.length) {

--- a/src/config_loader.js
+++ b/src/config_loader.js
@@ -189,7 +189,7 @@ export function parseJsonConfig(/**@type{string}*/text) {
   return JSON.parse(text, configJsonReviver);
 }
 
-export function stringifyJsonConfig(obj, space = 2) {
+export function stringifyJsonConfig(obj, space = 0) {
   return JSON.stringify(obj, configJsonReplacer, space);
 }
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -2,7 +2,10 @@ import {jest, expect, it, describe} from '@jest/globals';
 import {readFile} from 'fs/promises';
 
 import './helpers/fetch_local_polyfill.js';
-import { isComment, LoaderContext, parseJsonConfig, loadConfigFile } from "../src/config_loader.js";
+import { 
+  isComment, LoaderContext, parseJsonConfig, 
+  loadConfigFile, stringifyJsonConfig
+} from "../src/config_loader.js";
 import { deepMerge } from '../src/utils/deep_merge.js';
 import { PlayerConfig } from "../src/config.js";
 
@@ -58,6 +61,16 @@ describe("config_loader.js", () => {
     describe("LoaderContext.loadConfigByName", () => {test_loadConfigByName()});
     describe("LoaderContext.getConfigBases", () => {test_getBases()});
     runTestsFor_loadConfig();
+  });
+  describe("stringifyJsonConfig", () => {
+    it("Stringifies normal objects (no spaces)", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o));
+    });
+    it("Stringifies normal objects (space = 2)", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o, 2)).toStrictEqual(JSON.stringify(o, void 0, 2));
+    });
   });
 });
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -94,11 +94,23 @@ describe("config_loader.js", () => {
     it("Stringifies builtin symbol in root object", () => {
       let s = Symbol.unscopables;
       let o = {[s]: 123.4, other: [{}, "s"]};
-      expect(cnfStringifyToObj(o, 2)).toStrictEqual(rawStringifyToObj({
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
         "@@unscopables": 123.4,
         other: [{}, "s"]
       }));
-    })
+    });
+    it("Stringifies all symbols", () => {
+      let o = [0, {[Symbol.toStringTag]: "builtin", v: {[Symbol.for("symbol_k")]: []}}];
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj([0, {
+        "@@toStringTag": "builtin", v: {"@@symbol_k": []}
+      }]));
+    });
+    it("Ignores symbols in values", () => {
+      let o = {n: 8, smb: Symbol.toStringTag};
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
+        n: 8
+      }));
+    });
   });
 });
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -65,12 +65,16 @@ describe("config_loader.js", () => {
   describe("stringifyJsonConfig", () => {
     it("Stringifies normal objects (no spaces)", () => {
       let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
-      expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o));
+      expect(stringifyJsonConfig(o, 0)).toStrictEqual(JSON.stringify(o, 0));
     });
     it("Stringifies normal objects (space = 2)", () => {
       let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
       expect(stringifyJsonConfig(o, 2)).toStrictEqual(JSON.stringify(o, void 0, 2));
     });
+    it("Has default spaces at 0", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o, void 0, 0));
+    })
   });
 });
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -111,6 +111,23 @@ describe("config_loader.js", () => {
         n: 8
       }));
     });
+    describe.each([
+      "$comment",
+      "//",
+      "$#",
+      "#",
+      "/*"
+    ])("Handling of '%s' comments", (prefix) => {
+      it("Throws error if in key", () => {
+        expect(() => {
+          stringifyJsonConfig({[prefix + "extra-text"]: 77.7});
+        }).toThrow("comment");
+      });
+      it("Allows it in value", () => {
+        expect(cnfStringifyToObj([0, prefix + "extra-text", {}]))
+          .toStrictEqual([0, prefix + "extra-text", {}]);
+      })
+    });
   });
 });
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -39,6 +39,14 @@ function _withProto(obj, proto, {allNames=true, symbols=true}={}) {
   return res;
 }
 
+function rawStringifyToObj(o, space=2) {
+  return JSON.parse(JSON.stringify(o, void 0, space));
+}
+
+function cnfStringifyToObj(o, space=2) {
+  return JSON.parse(stringifyJsonConfig(o, space));
+}
+
 
 describe("config_loader.js", () => {
   describe("isComment (unit test)", () => { test_isComment() });
@@ -74,6 +82,22 @@ describe("config_loader.js", () => {
     it("Has default spaces at 0", () => {
       let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
       expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o, void 0, 0));
+    });
+    it("Stringifies symbols in root object (from Symbol.for)", () => {
+      let s = Symbol.for("__forTest");
+      let o = {[s]: 123.4, other: [{}, "s"]};
+      expect(cnfStringifyToObj(o, 2)).toStrictEqual(rawStringifyToObj({
+        "@@__forTest": 123.4,
+        other: [{}, "s"]
+      }));
+    });
+    it("Stringifies builtin symbol in root object", () => {
+      let s = Symbol.unscopables;
+      let o = {[s]: 123.4, other: [{}, "s"]};
+      expect(cnfStringifyToObj(o, 2)).toStrictEqual(rawStringifyToObj({
+        "@@unscopables": 123.4,
+        other: [{}, "s"]
+      }));
     })
   });
 });

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -71,63 +71,7 @@ describe("config_loader.js", () => {
     runTestsFor_loadConfig();
   });
   describe("stringifyJsonConfig", () => {
-    it("Stringifies normal objects (no spaces)", () => {
-      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
-      expect(stringifyJsonConfig(o, 0)).toStrictEqual(JSON.stringify(o, 0));
-    });
-    it("Stringifies normal objects (space = 2)", () => {
-      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
-      expect(stringifyJsonConfig(o, 2)).toStrictEqual(JSON.stringify(o, void 0, 2));
-    });
-    it("Has default spaces at 0", () => {
-      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
-      expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o, void 0, 0));
-    });
-    it("Stringifies symbols in root object (from Symbol.for)", () => {
-      let s = Symbol.for("__forTest");
-      let o = {[s]: 123.4, other: [{}, "s"]};
-      expect(cnfStringifyToObj(o, 2)).toStrictEqual(rawStringifyToObj({
-        "@@__forTest": 123.4,
-        other: [{}, "s"]
-      }));
-    });
-    it("Stringifies builtin symbol in root object", () => {
-      let s = Symbol.unscopables;
-      let o = {[s]: 123.4, other: [{}, "s"]};
-      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
-        "@@unscopables": 123.4,
-        other: [{}, "s"]
-      }));
-    });
-    it("Stringifies all symbols", () => {
-      let o = [0, {[Symbol.toStringTag]: "builtin", v: {[Symbol.for("symbol_k")]: []}}];
-      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj([0, {
-        "@@toStringTag": "builtin", v: {"@@symbol_k": []}
-      }]));
-    });
-    it("Ignores symbols in values", () => {
-      let o = {n: 8, smb: Symbol.toStringTag};
-      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
-        n: 8
-      }));
-    });
-    describe.each([
-      "$comment",
-      "//",
-      "$#",
-      "#",
-      "/*"
-    ])("Handling of '%s' comments", (prefix) => {
-      it("Throws error if in key", () => {
-        expect(() => {
-          stringifyJsonConfig({[prefix + "extra-text"]: 77.7});
-        }).toThrow("comment");
-      });
-      it("Allows it in value", () => {
-        expect(cnfStringifyToObj([0, prefix + "extra-text", {}]))
-          .toStrictEqual([0, prefix + "extra-text", {}]);
-      })
-    });
+    test_stringify();
   });
 });
 
@@ -695,4 +639,65 @@ function test_loadConfig_root() {
       proto.loadConfigFile = orig;
     }
   });
+}
+
+
+function test_stringify() {
+  it("Stringifies normal objects (no spaces)", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o, 0)).toStrictEqual(JSON.stringify(o, 0));
+    });
+    it("Stringifies normal objects (space = 2)", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o, 2)).toStrictEqual(JSON.stringify(o, void 0, 2));
+    });
+    it("Has default spaces at 0", () => {
+      let o = {arr: [23, "a str", "escapes: \n\\\\\t", {}], n: -22, n1: 0, x: [[], {}]};
+      expect(stringifyJsonConfig(o)).toStrictEqual(JSON.stringify(o, void 0, 0));
+    });
+    it("Stringifies symbols in root object (from Symbol.for)", () => {
+      let s = Symbol.for("__forTest");
+      let o = {[s]: 123.4, other: [{}, "s"]};
+      expect(cnfStringifyToObj(o, 2)).toStrictEqual(rawStringifyToObj({
+        "@@__forTest": 123.4,
+        other: [{}, "s"]
+      }));
+    });
+    it("Stringifies builtin symbol in root object", () => {
+      let s = Symbol.unscopables;
+      let o = {[s]: 123.4, other: [{}, "s"]};
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
+        "@@unscopables": 123.4,
+        other: [{}, "s"]
+      }));
+    });
+    it("Stringifies all symbols", () => {
+      let o = [0, {[Symbol.toStringTag]: "builtin", v: {[Symbol.for("symbol_k")]: []}}];
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj([0, {
+        "@@toStringTag": "builtin", v: {"@@symbol_k": []}
+      }]));
+    });
+    it("Ignores symbols in values", () => {
+      let o = {n: 8, smb: Symbol.toStringTag};
+      expect(cnfStringifyToObj(o)).toStrictEqual(rawStringifyToObj({
+        n: 8
+      }));
+    });
+    describe.each([
+      "$comment",
+      "//",
+      "$#",
+      "#",
+      "/*"
+    ])("Handling of '%s' comments", (prefix) => {
+      it("Throws error if in key", () => {
+        expect(() => {
+          stringifyJsonConfig({[prefix + "extra-text"]: 77.7});
+        }).toThrow("comment");
+      });
+      it("Allows it in value", () => {
+        expect(cnfStringifyToObj([0, prefix + "extra-text", {}]))
+          .toStrictEqual([0, prefix + "extra-text", {}]);
+      })
+    });
 }


### PR DESCRIPTION
- [x] Tests for normal json stringifying
- [x] Symbol keys handling
- [x] Tests for symbol keys
- [x] Error for keys that would be comments
- [x] Tests for comment keys
- [ ] (maybe) `configsRoot` argument + inheritance - how would that work?
- [ ] Tests for inheritance (see above)
- [x] Tests for infinity handling
- [x] Tests for class handling