### PR TITLE
Add version indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
       <br>
     </div>
   </div>
+  <div id="other-info">
+    <div id="version-div">Version <span id="version-info">???</span></div>
+  </div>
   <div id="links">
     Made by <a href="https://github.com/MarcellPerger1" target="_blank" rel="noopener noreferrer">Marcell Perger</a>.
     <br>

--- a/src/current_version_loader.js
+++ b/src/current_version_loader.js
@@ -1,0 +1,28 @@
+import { fetchJsonFile } from "./utils/file_load.js";
+
+// I know its a bit silly to make a request to fetch the version info
+// but I don't want to hard-code it in a file as I will forget to change it.
+var _version_cache = null;
+
+async function _loadVersionInfo() {
+  let package_info = await fetchJsonFile("./package.json");
+  let version = package_info.version;
+  if(!version) {
+    throw new TypeError("Invalid package.json, doesn't contain a version number")
+  }
+  return version;
+}
+
+export async function loadVersionInfo() {
+  if(_version_cache) return _version_cache;
+  return (_version_cache = await _loadVersionInfo());
+}
+
+
+export var currentVersionLoader = {
+  async loadResources() {
+    let version = currentVersionLoader.version = await loadVersionInfo();
+    document.getElementById("version-info").innerText = version;
+  },
+  version: null
+};

--- a/src/game.js
+++ b/src/game.js
@@ -5,6 +5,7 @@ import { Player } from './player.js';
 import { WorldGenerator } from './world.js';
 import { LoadingEndMgr } from './loading_end.js';
 import { DynInfo } from './dyn_info.js';
+import { currentVersionLoader } from './current_version_loader.js'
 
 
 /**
@@ -94,7 +95,7 @@ export class Game {
     /**
      * @type {Array<{loadResources: () => void}>}
      */
-    this.resourceLoaders = [this.r];
+    this.resourceLoaders = [this.r, currentVersionLoader];
   }
 
   joinResourceLoaders() {


### PR DESCRIPTION
Add version indicator. 
It currently loads the version number from the `package.json` file which might not be the best idea but its better than hard-coding the version number in a `.js` file as I ***will*** forget to update it.