### PR TITLE
refactor!: Remove `checkError` fully, fixes #155

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -7,7 +7,6 @@
     1
   ],
   "canvasSize": [640, 480],
-  "checkError": false,
   "generation": {
     "$class": "GenerationConfig",
     "seed": "secret-seed",

--- a/src/config.js
+++ b/src/config.js
@@ -81,7 +81,6 @@ export class AtlasConfig extends BaseConfig {}
  * @typedef {Object} ConfigT
  * @property {RGBA_Tuple} bgColor
  * @property {Vec2} canvasSize
- * @property {boolean} checkError
  * @property {GenerationConfigT} generation
  * @property {ControlsConfigT} controls
  * @property {PlayerConfigT} player


### PR DESCRIPTION
BREAKING CHANGE: Remove options to check WebGL errors as its slow and devtools reports these anyway, see issue #155.

(cherry picked from commit ecc517f102de31e9183b4d00c9ca2f7fc3b13d0d)