### PR TITLE
Dont use prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
         "before": true,
         "after": false
       }
-    }]
+    }],
+    "indent": ["warn", 2]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,19 @@
       "before": false, "after": true
     }],
     "comma-style": ["warn", "last"],
-    "computed-property-spacing": ["warn", "never"]
+    "computed-property-spacing": ["warn", "never"],
+    "dot-location": ["warn", "property"],
+    "eol-last": ["warn", "always"],
+    "func-call-spacing": ["warn", "never"],
+    "function-call-argument-newline": ["warn", "always"],
+    "function-paren-newline": ["warn", "multiline"],
+    "generator-star-spacing": ["warn", {
+      "after": true,
+      "before": false,
+      "method": {
+        "before": true,
+        "after": false
+      }
+    }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,14 @@
     "arrow-parens": ["warn", "always"],
     "arrow-spacing": ["warn", {
       "before": true, "after": true
-    }]
+    }],
+    "block-spacing": ["warn", "always"],
+    "brace-style": ["warn", "1tbs"],
+    "always-multiline": ["warn", "always-multiline"],
+    "comma-spacing": ["warn", {
+      "before": false, "after": true
+    }],
+    "comma-style": ["warn", "last"],
+    "computed-property-spacing": ["warn", "never"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     }],
     "block-spacing": ["warn", "always"],
     "brace-style": ["warn", "1tbs"],
-    "always-multiline": ["warn", "always-multiline"],
+    "comma-dangle": ["warn", "always-multiline"],
     "comma-spacing": ["warn", {
       "before": false, "after": true
     }],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,18 @@
     "no-unused-vars": ["warn", {
       "varsIgnorePattern": "^_",
       "argsIgnorePattern": "^_"
+    }],
+    "array-bracket-newline": ["warn", {
+      "multiline": true,
+      "minItems": null
+    }],
+    "array-bracket-spacing": ["warn", "never"],
+    "array-element-newline": ["warn", {
+      "multiline": true
+    }],
+    "arrow-parens": ["warn", "always"],
+    "arrow-spacing": ["warn", {
+      "before": true, "after": true
     }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "progress": "writable"
   },
   "rules": {
-    "no-unused-vars": ["warn", {
+    "no-unused-vars": ["error", {
       "varsIgnorePattern": "^_",
       "argsIgnorePattern": "^_"
     }],


### PR DESCRIPTION
Don't use prettier because operators at the end of lines are bad, and less readable, see PEP8.

ESLint is bad for this because:
- It is too customizable so it would take ages for me to fully make it like I want it.
- Sometimes, it doesn't automatically correct it, just checks it which defeats the point of a formatter.

Other options to consider (in order from least to most effort):
- Keep using prettier (and hope that prettier/prettier#3806 is fixed)
- clang-format: I've already customized fully for a different project (yes, all 100+ rules) but it seems to be more focused towards C/C++
- Look for some better JS formatter
- Make my own JS formatter/prettier fork