### PR TITLE
Use `github-actions` as author of auto-format commits

### DIFF
--- a/.github/workflows/format_code.yml
+++ b/.github/workflows/format_code.yml
@@ -23,4 +23,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: Format code"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           


### PR DESCRIPTION
Use `github-actions` as author of auto-format commits